### PR TITLE
Fix/tsc build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "karma start --single-run",
     "test:watch": "karma start",
+    "tsc": "tsc",
     "rollup": "rollup -c"
   },
   "devDependencies": {

--- a/source/Web/Scripts/modules/console-view.ts
+++ b/source/Web/Scripts/modules/console-view.ts
@@ -1,9 +1,8 @@
-import { BufferedTerminal } from './buffered-terminal';
+import { ResizeSensor } from 'css-element-queries';
 import { FitAddon } from 'xterm-addon-fit';
 import { WebLinksAddon } from 'xterm-addon-web-links';
 import * as XtermWebfont from 'xterm-webfont';
-import { ResizeSensor } from 'css-element-queries';
-import { Terminal } from 'xterm';
+import { BufferedTerminal } from './buffered-terminal';
 import { TextReceived } from './console-hub';
 
 export interface ConsoleViewSettings {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "target": "es2015",
     "lib": ["dom", "es2015"],
-    "module": "ES2015",
+    "module": "ES2015"
   },
+  "include": ["node_modules/xterm/typings/xterm.d.ts"]
 }
 
 // TODO: How can TypeScript errors in VS Code be prevented with the current tsconfig.json?


### PR DESCRIPTION
Ich bin mir nicht sicher weshalb es notwendig ist, aber ich habe in der tsconfig.json xterms type-definitions hinterlegt, und damit wird die lib und die addons richtig aufgelöst.

Das webfont-addon wird mit `any` typisiert, weil es keine type-definitions beinhaltet.

Auf die Idee bin ich gekommen als ich in xterms Repo in deren Demo geschaut habe: https://github.com/xtermjs/xterm.js/blob/master/demo/tsconfig.json